### PR TITLE
Refactor metrics to use prometheus.Collector interface

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,8 +25,7 @@ func main() {
 
 	metricCollector := metric.NewCollector()
 
-	statGatherer := stat.NewGatherer(cli, metricCollector)
-	metricCollector.RegisterGatherer(statGatherer)
+	metricCollector.Register(stat.NewGatherer(cli))
 
 	evHandler := event.NewHandler(cli, metricCollector)
 

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -29,7 +29,7 @@
         "includeAll": true,
         "allValue": ".+",
         "query": {
-          "query": "label_values(docker_mem_stat_bytes, instance)",
+          "query": "label_values(docker_mem_usage_bytes, instance)",
           "refId": "StandardVariableQuery"
         },
         "sort": 1
@@ -45,7 +45,7 @@
         "includeAll": true,
         "allValue": ".+",
         "query": {
-          "query": "label_values(docker_mem_stat_bytes{instance=~\"${target}\"}, containerName)",
+          "query": "label_values(docker_mem_usage_bytes{instance=~\"${target}\"}, containerName)",
           "refId": "StandardVariableQuery"
         },
         "sort": 1
@@ -61,7 +61,7 @@
         "includeAll": true,
         "allValue": ".+",
         "query": {
-          "query": "label_values(docker_mem_stat_bytes{instance=~\"${target}\"}, serviceName)",
+          "query": "label_values(docker_mem_usage_bytes{instance=~\"${target}\"}, serviceName)",
           "refId": "StandardVariableQuery"
         },
         "sort": 1
@@ -102,7 +102,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "count(count by (containerName) (docker_mem_stat_bytes{instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}))",
+          "expr": "count(count by (containerName) (docker_mem_usage_bytes{instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}))",
           "legendFormat": "Containers"
         }
       ]
@@ -151,7 +151,7 @@
     {
       "id": 5,
       "type": "timeseries",
-      "title": "CPU Usage (usermode + kernelmode)",
+      "title": "CPU Usage Rate (cores)",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
       "options": {
@@ -160,7 +160,8 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "ns",
+          "unit": "short",
+          "decimals": 3,
           "custom": { "lineWidth": 1, "fillOpacity": 5 }
         }
       },
@@ -168,7 +169,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_cpu_stat_ns{type=\"usermode\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"} + ignoring(type) docker_cpu_stat_ns{type=\"kernelmode\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "(rate(docker_cpu_usage_ns_total{type=\"usermode\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m]) + ignoring(type) rate(docker_cpu_usage_ns_total{type=\"kernelmode\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m])) / 1e9",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -176,7 +177,7 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "CPU Throttled Time",
+      "title": "CPU Throttled Rate (cores)",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
       "options": {
@@ -185,7 +186,8 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "ns",
+          "unit": "short",
+          "decimals": 3,
           "custom": { "lineWidth": 1, "fillOpacity": 5 },
           "color": { "mode": "palette-classic" }
         }
@@ -194,7 +196,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_cpu_stat_ns{type=\"throttled\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "rate(docker_cpu_usage_ns_total{type=\"throttled\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m]) / 1e9",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -226,7 +228,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_mem_stat_bytes{type=\"used\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "docker_mem_usage_bytes{type=\"used\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -241,7 +243,7 @@
     {
       "id": 10,
       "type": "timeseries",
-      "title": "Network Received (RX)",
+      "title": "Network Received Rate (RX)",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
       "options": {
@@ -250,7 +252,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "Bps",
           "custom": { "lineWidth": 1, "fillOpacity": 5 }
         }
       },
@@ -258,7 +260,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_net_stat_bytes{type=\"rx\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "rate(docker_net_bytes_total{type=\"rx\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m])",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -266,7 +268,7 @@
     {
       "id": 11,
       "type": "timeseries",
-      "title": "Network Transmitted (TX)",
+      "title": "Network Transmitted Rate (TX)",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
       "options": {
@@ -275,7 +277,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "Bps",
           "custom": { "lineWidth": 1, "fillOpacity": 5 }
         }
       },
@@ -283,7 +285,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_net_stat_bytes{type=\"tx\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "rate(docker_net_bytes_total{type=\"tx\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m])",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -291,7 +293,7 @@
     {
       "id": 12,
       "type": "timeseries",
-      "title": "Network Drops",
+      "title": "Network Drop Rate",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
       "options": {
@@ -300,7 +302,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "pps",
           "custom": { "lineWidth": 1, "fillOpacity": 5 },
           "color": { "mode": "fixed", "fixedColor": "orange" }
         }
@@ -309,7 +311,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_net_stat_bytes{type=\"drop\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "rate(docker_net_bytes_total{type=\"drop\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m])",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]
@@ -317,7 +319,7 @@
     {
       "id": 13,
       "type": "timeseries",
-      "title": "Network Errors",
+      "title": "Network Error Rate",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
       "options": {
@@ -326,7 +328,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
+          "unit": "pps",
           "custom": { "lineWidth": 1, "fillOpacity": 5 },
           "color": { "mode": "fixed", "fixedColor": "red" }
         }
@@ -335,7 +337,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "docker_net_stat_bytes{type=\"error\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}",
+          "expr": "rate(docker_net_bytes_total{type=\"error\", instance=~\"${target}\", containerName=~\"${container}\", serviceName=~\"${service}\"}[5m])",
           "legendFormat": "{{containerName}} ({{instance}})"
         }
       ]

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -10,17 +10,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type Gatherer interface {
-	Metrics() []prometheus.Collector
-	Gather()
-}
-
 type Collector struct {
 	event *prometheus.CounterVec
 
 	reg                *prometheus.Registry
 	defaultHandlerFunc http.Handler
-	gatherers          []Gatherer
 }
 
 func NewCollector() *Collector {
@@ -44,11 +38,8 @@ func NewCollector() *Collector {
 	return c
 }
 
-func (c *Collector) RegisterGatherer(gatherer Gatherer) {
-	for _, m := range gatherer.Metrics() {
-		c.reg.MustRegister(m)
-	}
-	c.gatherers = append(c.gatherers, gatherer)
+func (c *Collector) Register(collector prometheus.Collector) {
+	c.reg.MustRegister(collector)
 }
 
 func (c *Collector) RegisterEvent(containerName, serviceName, serviceID, eventType string) {
@@ -62,21 +53,9 @@ func (c *Collector) RegisterEvent(containerName, serviceName, serviceID, eventTy
 	).Inc()
 }
 
-func (c *Collector) handler() http.Handler {
-	h := func(w http.ResponseWriter, r *http.Request) {
-		for _, g := range c.gatherers {
-			fmt.Printf("invoke gatherer\n")
-			g.Gather()
-		}
-		fmt.Printf("invoke metric handler\n")
-		c.defaultHandlerFunc.ServeHTTP(w, r)
-	}
-	return http.HandlerFunc(h)
-}
-
 func (c *Collector) ExposeHTTP(ctx context.Context) {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", c.handler())
+	mux.Handle("/metrics", c.defaultHandlerFunc)
 
 	s := http.Server{
 		Addr:    ":8080",

--- a/internal/stat/stat.go
+++ b/internal/stat/stat.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/alexeynavarkin/docker_exporter/internal/metric"
 	"github.com/alexeynavarkin/docker_exporter/internal/util"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -17,62 +16,47 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var labelsContainer = []string{"containerName", "serviceName", "serviceID", "type"}
-
 type response struct {
 	NetworkStats map[string]types.NetworkStats `json:"networks"`
 	MemStats     types.MemoryStats             `json:"memory_stats"`
 	CpuStats     types.CPUStats                `json:"cpu_stats"`
 }
 
+var (
+	labelNames = []string{"containerName", "serviceName", "serviceID", "type"}
+
+	descCPU = prometheus.NewDesc(
+		"docker_cpu_usage_ns_total",
+		"Cumulative container CPU usage in nanoseconds.",
+		labelNames, nil,
+	)
+	descMem = prometheus.NewDesc(
+		"docker_mem_usage_bytes",
+		"Container memory usage in bytes.",
+		labelNames, nil,
+	)
+	descNet = prometheus.NewDesc(
+		"docker_net_bytes_total",
+		"Cumulative container network I/O in bytes.",
+		labelNames, nil,
+	)
+)
+
 type Gatherer struct {
-	metricCpuStats *prometheus.GaugeVec
-	metricMemStats *prometheus.GaugeVec
-	metricNetStats *prometheus.GaugeVec
-
-	cli             *client.Client
-	metricCollector *metric.Collector
+	cli *client.Client
 }
 
-func NewGatherer(cli *client.Client, metricCollector *metric.Collector) *Gatherer {
-	return &Gatherer{
-		metricCpuStats: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "docker",
-				Subsystem: "cpu",
-				Name:      "stat_ns",
-				Help:      "Container cpu usage.",
-			},
-			labelsContainer,
-		),
-		metricMemStats: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "docker",
-				Subsystem: "mem",
-				Name:      "stat_bytes",
-				Help:      "Container memory usage.",
-			},
-			labelsContainer,
-		),
-		metricNetStats: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "docker",
-				Subsystem: "net",
-				Name:      "stat_bytes",
-				Help:      "Container network usage.",
-			},
-			labelsContainer,
-		),
-		cli:             cli,
-		metricCollector: metricCollector,
-	}
+func NewGatherer(cli *client.Client) *Gatherer {
+	return &Gatherer{cli: cli}
 }
 
-func (g *Gatherer) Gather() {
-	g.metricCpuStats.Reset()
-	g.metricMemStats.Reset()
-	g.metricNetStats.Reset()
+func (g *Gatherer) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descCPU
+	ch <- descMem
+	ch <- descNet
+}
 
+func (g *Gatherer) Collect(ch chan<- prometheus.Metric) {
 	containers, err := g.cli.ContainerList(
 		context.Background(),
 		container.ListOptions{
@@ -87,108 +71,50 @@ func (g *Gatherer) Gather() {
 	var wg sync.WaitGroup
 	wg.Add(len(containers))
 	for _, c := range containers {
-		fmt.Printf("collect stats for container %s\n", c.ID)
-		go g.collectContainer(c, &wg)
+		go func(c types.Container) {
+			defer wg.Done()
+			g.collectContainer(c, ch)
+		}(c)
 	}
 	wg.Wait()
-	fmt.Print("collect done\n")
 }
 
-func (g *Gatherer) collectContainer(c types.Container, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (g *Gatherer) collectContainer(c types.Container, ch chan<- prometheus.Metric) {
 	stats, _ := g.cli.ContainerStats(context.Background(), c.ID, false)
 	data, _ := io.ReadAll(stats.Body)
 	var resp response
-	err := json.Unmarshal(data, &resp)
-	if err != nil {
+	if err := json.Unmarshal(data, &resp); err != nil {
 		return
 	}
 
 	containerName := strings.Join(c.Names, "")
+	svcName := util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue)
+	svcID := util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue)
 
-	m, _ := g.metricMemStats.GetMetricWith(
-		prometheus.Labels{
-			"containerName": containerName,
-			"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-			"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-			"type":          "used",
-		},
-	)
-	m.Set(float64(resp.MemStats.Usage))
+	label := func(t string) []string { return []string{containerName, svcName, svcID, t} }
 
-	m, _ = g.metricCpuStats.GetMetricWith(
-		prometheus.Labels{
-			"containerName": containerName,
-			"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-			"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-			"type":          "usermode",
-		},
-	)
-	m.Set(float64(resp.CpuStats.CPUUsage.UsageInUsermode))
-	m, _ = g.metricCpuStats.GetMetricWith(
-		prometheus.Labels{
-			"containerName": containerName,
-			"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-			"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-			"type":          "kernelmode",
-		},
-	)
-	m.Set(float64(resp.CpuStats.CPUUsage.UsageInKernelmode))
-	m, _ = g.metricCpuStats.GetMetricWith(
-		prometheus.Labels{
-			"containerName": containerName,
-			"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-			"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-			"type":          "throttled",
-		},
-	)
-	m.Set(float64(resp.CpuStats.ThrottlingData.ThrottledTime))
+	// Memory — gauge, current usage
+	ch <- prometheus.MustNewConstMetric(descMem, prometheus.GaugeValue,
+		float64(resp.MemStats.Usage), label("used")...)
 
+	// CPU — counter, absolute cumulative nanoseconds from Docker
+	ch <- prometheus.MustNewConstMetric(descCPU, prometheus.CounterValue,
+		float64(resp.CpuStats.CPUUsage.UsageInUsermode), label("usermode")...)
+	ch <- prometheus.MustNewConstMetric(descCPU, prometheus.CounterValue,
+		float64(resp.CpuStats.CPUUsage.UsageInKernelmode), label("kernelmode")...)
+	ch <- prometheus.MustNewConstMetric(descCPU, prometheus.CounterValue,
+		float64(resp.CpuStats.ThrottlingData.ThrottledTime), label("throttled")...)
+
+	// Network — counter, sum all interfaces, absolute cumulative bytes from Docker
+	var rx, tx, drop, errs uint64
 	for _, iface := range resp.NetworkStats {
-		m, _ = g.metricNetStats.GetMetricWith(
-			prometheus.Labels{
-				"containerName": containerName,
-				"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-				"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-				"type":          "rx",
-			},
-		)
-		m.Add((float64(iface.RxBytes)))
-		m, _ = g.metricNetStats.GetMetricWith(
-			prometheus.Labels{
-				"containerName": containerName,
-				"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-				"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-				"type":          "tx",
-			},
-		)
-		m.Add((float64(iface.TxBytes)))
-		m, _ = g.metricNetStats.GetMetricWith(
-			prometheus.Labels{
-				"containerName": containerName,
-				"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-				"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-				"type":          "drop",
-			},
-		)
-		m.Add((float64(iface.RxDropped + iface.TxDropped)))
-		m, _ = g.metricNetStats.GetMetricWith(
-			prometheus.Labels{
-				"containerName": containerName,
-				"serviceName":   util.GetMapValue(c.Labels, util.LabelNameServiceName, util.LabelDefaultValue),
-				"serviceID":     util.GetMapValue(c.Labels, util.LabelNameServiceID, util.LabelDefaultValue),
-				"type":          "error",
-			},
-		)
-		m.Add((float64(iface.RxErrors + iface.TxErrors)))
+		rx += iface.RxBytes
+		tx += iface.TxBytes
+		drop += iface.RxDropped + iface.TxDropped
+		errs += iface.RxErrors + iface.TxErrors
 	}
-}
-
-func (g *Gatherer) Metrics() []prometheus.Collector {
-	return []prometheus.Collector{
-		g.metricCpuStats,
-		g.metricMemStats,
-		g.metricNetStats,
-	}
+	ch <- prometheus.MustNewConstMetric(descNet, prometheus.CounterValue, float64(rx), label("rx")...)
+	ch <- prometheus.MustNewConstMetric(descNet, prometheus.CounterValue, float64(tx), label("tx")...)
+	ch <- prometheus.MustNewConstMetric(descNet, prometheus.CounterValue, float64(drop), label("drop")...)
+	ch <- prometheus.MustNewConstMetric(descNet, prometheus.CounterValue, float64(errs), label("error")...)
 }


### PR DESCRIPTION
- Implement stat.Gatherer as prometheus.Collector (Describe+Collect)
- Emit CPU and network as CounterValue with absolute Docker values
- Remove manual delta tracking, Reset/Add pattern
- Simplify metric.Collector, drop custom Gatherer interface
- Update Grafana dashboard: deriv->rate, new metric names
- Upgrade Docker SDK to v26, fix API 1.44 compat